### PR TITLE
Fixes character range issue with fakeCapitalLetter

### DIFF
--- a/src/Fake/Combinators.hs
+++ b/src/Fake/Combinators.hs
@@ -163,5 +163,5 @@ fakeLetter = fakeEnumFromTo 'a' 'z'
 
 ------------------------------------------------------------------------------
 fakeCapitalLetter :: FGen Char
-fakeCapitalLetter = fakeEnumFromTo 'A' 'A'
+fakeCapitalLetter = fakeEnumFromTo 'A' 'Z'
 


### PR DESCRIPTION
Thanks for writing this handy library! I noticed an issue when playing around with the `fakeCapitalLetter` combinator. It only generates `A` characters.

Before patch:
```
> replicateM 26 (generate fakeCapitalLetter)
"AAAAAAAAAAAAAAAAAAAAAAAAAA"
```

After patch:
```
> replicateM 26 (generate fakeCapitalLetter)
"AIVTPLSDFVOVULULTDBFLZJEVF"
```
