### PR TITLE
Fixed exception in firefoxUserAgent

### DIFF
--- a/src/Fake/Provider/UserAgent.hs
+++ b/src/Fake/Provider/UserAgent.hs
@@ -109,7 +109,7 @@ firefoxUserAgent = do
         mac = do
           plat <- macPlatform
           n <- fakeInt 2 6
-          return $ printf "(%s; rv:1.9.%d.20) %s" plat n
+          return $ printf "(%s; rv:1.9.%d.20) %s" plat n ver
     plat <- oneof [win, lin, mac]
     return $ "Mozilla/5.0 " <> plat
 


### PR DESCRIPTION
Hi, thank you for this library! 

Using `firefoxUserAgent` (and hence `userAgent`) could throw a printf exception. I see this library relies heavily on printf and wondered if you have considered using something safer like the `formatting` library? < https://hackage.haskell.org/package/formatting >

Thanks,
Tim